### PR TITLE
Fix encoder errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,7 @@
 /deps/build
 *.pcm
 *.opus
-node_modules/
 .vscode
+.gitignore
+.jshintrc
+.travis.yml

--- a/lib/Encoder.js
+++ b/lib/Encoder.js
@@ -55,7 +55,7 @@ Encoder.prototype._writeHeader = function() {
     var data = new Buffer([
         0x01,  // version
         this.channels,
-        0x00, 0x00,  // Preskip (TODO: how do we get this?)
+        0x00, 0x0f,  // Preskip (default and recommended 3840)
         ( ( this.rate & 0x000000ff ) >> 0 ),
         ( ( this.rate & 0x0000ff00 ) >> 8 ),
         ( ( this.rate & 0x00ff0000 ) >> 16 ),
@@ -74,9 +74,9 @@ Encoder.prototype._writeHeader = function() {
     packet.e_o_s = 0;
     packet.granulepos = 0;
     packet.packetno = this.pos++;
-    //packet.flush = true;
 
     this.push( packet );
+    this.samplesWritten += header.length;
 
 	// OpusTags packet
     magicSignature = new Buffer( 'OpusTags', 'ascii' );
@@ -95,7 +95,7 @@ Encoder.prototype._writeHeader = function() {
     packet.bytes = header.length;
     packet.b_o_s = 0;
     packet.e_o_s = 0;
-    packet.granulepos = 0;
+    packet.granulepos = this.samplesWritten;
     packet.packetno = this.pos++;
     packet.flush = true;
 
@@ -149,7 +149,13 @@ Encoder.prototype._processOutput = function( buf ) {
 
 Encoder.prototype._flushFrame = function( frame, end ) {
 
+    if( this.lastPacket ) {
+        this.push( this.lastPacket );
+    }
+
     var encoded = this.encoder.encode( frame );
+
+    this.samplesWritten += this.frameSize;
 
     var packet = new ogg_packet();
     packet.packet = encoded;
@@ -160,23 +166,15 @@ Encoder.prototype._flushFrame = function( frame, end ) {
     packet.packetno = this.pos++;
 	packet.flush = true;
 
-    this.samplesWritten += this.frameSize;
-
-    this.push( packet );
+    this.lastPacket = packet;
 };
 
 Encoder.prototype._flush = function( done ) {
 
-    var packet = new ogg_packet();
-    packet.packet = new Buffer(0);
-    packet.bytes = 0;
-    packet.b_o_s = 0;
-    packet.e_o_s = 1;
-    packet.granulepos = this.pos;
-    packet.packetno = this.pos++;
-    packet.flush = true;
-
-    this.push( packet );
+    if( this.lastPacket ) {
+        this.lastPacket.e_o_s = 1;
+        this.push( this.lastPacket );
+    }
 
     done();
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-opus",
   "description": "NodeJS native binding to OPUS",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Mikko Rantanen <jubjub@jubjubnest.net>",
   "homepage": "https://github.com/Rantanen/node-opus",
   "bugs": "https://github.com/Rantanen/node-opus/issues",


### PR DESCRIPTION
Hi @Rantanen,
I fixed some errors in the encoder. The main issue was that the duration of the audio was bad because handling of packets and had some warnings from the `opusinfo` tool which I have fixed. The pre-skip size is the recommended size from the OggOpus documentation. I think this value is better than zero.

Encoded audio duration fixed
granulepos fixed
Pre-skip size fixed (defaults to the recommended 3840)
