### PR TITLE
Remove deprecated Buffer methods

### DIFF
--- a/lib/Encoder.js
+++ b/lib/Encoder.js
@@ -24,7 +24,7 @@ var Encoder = function( rate, channels, frameSize ) {
     this.frameSize = frameSize || this.rate * 0.04;
 
     this.encoder = new OpusEncoder( this.rate, this.channels );
-    this.frameOverflow = new Buffer(0);
+    this.frameOverflow = Buffer.alloc(0);
 
     this.headerWritten = false;
     this.pos = 0;
@@ -47,8 +47,8 @@ Encoder.prototype._transform = function( buf, encoding, done ) {
 Encoder.prototype._writeHeader = function() {
 
 	// OpusHead packet
-    var magicSignature = new Buffer( 'OpusHead', 'ascii' );
-    var data = new Buffer([
+    var magicSignature = Buffer.from( 'OpusHead', 'ascii' );
+    var data = Buffer.from([
         0x01,  // version
         this.channels,
         0x00, 0x0f,  // Preskip (default and recommended 3840)
@@ -74,15 +74,15 @@ Encoder.prototype._writeHeader = function() {
     this.push( packet );
 
 	// OpusTags packet
-    magicSignature = new Buffer( 'OpusTags', 'ascii' );
-    var vendor = new Buffer( 'node-opus', 'ascii' );
-    var vendorLength = new Buffer( 4 );
+    magicSignature = Buffer.from( 'OpusTags', 'ascii' );
+    var vendor = Buffer.from( 'node-opus', 'ascii' );
+    var vendorLength = Buffer.alloc( 4 );
     vendorLength.writeUInt32LE( vendor.length, 0 );
-    var commentLength = new Buffer( 4 );
+    var commentLength = Buffer.alloc( 4 );
     commentLength.writeUInt32LE( 0, 0 );
 
-    header = new Buffer.concat([
-        magicSignature, vendorLength, vendor, commentLength, new Buffer([ 0xff ])
+    header = Buffer.concat([
+        magicSignature, vendorLength, vendor, commentLength, Buffer.from([ 0xff ])
     ]);
 
     packet = new ogg_packet();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ia32"
   ],
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.5.0"
   },
   "dependencies": {
     "bindings": "~1.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ia32"
   ],
   "engines": {
-    "node": ">=4.5.0"
+    "node": ">=5.10.0"
   },
   "dependencies": {
     "bindings": "~1.2.1",

--- a/test/old/app.js
+++ b/test/old/app.js
@@ -14,7 +14,7 @@ var rate = 48000;
 // Allocate a buffer for the tone. We use 16-bit samples.
 var samples = rate*time;
 var length = samples*2;
-var b = new Buffer(length);
+var b = Buffer.alloc(length);
 
 // Generate the tone.
 for( var i = 0; i < rate*time; i++ ) {
@@ -41,7 +41,7 @@ while( b.length > 0 ) {
     
     // If the input buffer is smaller than the frame_size, copy it into a new 0-padded buffer.
 	if( size < frame_size ) {
-		var temp = new Buffer( frame_size );
+		var temp = Buffer.alloc( frame_size );
         temp.fill(0);
         b.copy( temp );
         b = temp;


### PR DESCRIPTION
Starting from Node.js v6, instantiating Buffers with `new Buffer` is deprecated (seen in docs [here](https://nodejs.org/docs/latest-v6.x/api/buffer.html)).

This PR updates the deprecated methods, but it also means the minimum version of Node.js required is now `5.10.0` as opposed to `0.10`. It might be better to update now before the methods are eventually removed!