### PR TITLE
Make node-opus context-aware

### DIFF
--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -243,6 +243,8 @@ class OpusEncoder : public ObjectWrap {
 };
 
 
-NODE_MODULE_INITIALIZER( Local< Object > exports, Local< Value > module, Local< Context > context ) {
+void NodeInit( Local< Object > exports ) {
 	OpusEncoder::Init( exports );
 }
+
+NODE_MODULE(node_opus, NodeInit)

--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -243,8 +243,6 @@ class OpusEncoder : public ObjectWrap {
 };
 
 
-void NodeInit( Local< Object > exports ) {
+NODE_MODULE_INIT( Local< Object > exports, Local< Value > module, Local< Context > context ) {
 	OpusEncoder::Init( exports );
 }
-
-NODE_MODULE(node_opus, NodeInit)

--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -243,6 +243,6 @@ class OpusEncoder : public ObjectWrap {
 };
 
 
-NODE_MODULE_INIT( Local< Object > exports, Local< Value > module, Local< Context > context ) {
+NODE_MODULE_INITIALIZER( Local< Object > exports, Local< Value > module, Local< Context > context ) {
 	OpusEncoder::Init( exports );
 }

--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -247,4 +247,4 @@ void NodeInit( Local< Object > exports ) {
 	OpusEncoder::Init( exports );
 }
 
-NODE_MODULE(node_opus, NodeInit)
+NODE_MODULE_CONTEXT_AWARE(node_opus, NodeInit)


### PR DESCRIPTION
I don't know how much performance gain we can get from this, but when I tried to use this module in [worker threads](https://nodejs.org/api/worker_threads.html) it throws errors. I patched it and now it should be context aware.

**NOTE**: I am no means a C++ developer. I merely follow instructions from [here](https://nodejs.org/api/addons.html#addons_context_aware_addons) and referred to [`better-sqlite3`'s effort](https://github.com/JoshuaWise/better-sqlite3/pull/311). I need someone to check and help improve this PR.